### PR TITLE
changes, meeting specs 2/3 and 3/3, not 1/3

### DIFF
--- a/twtxt/Utests.txt
+++ b/twtxt/Utests.txt
@@ -149,7 +149,7 @@ def timeline(ctx, pager, limit, twtfile, sorting, timeout, porcelain, source, ca
         tweets.extend(get_local_tweets(source, limit))
 
     tweets = sort_and_truncate_tweets(tweets, sorting, limit)
-    # move if not tweets here if cache dtt, works with 3/ v
+    # move if not tweets here
     if not tweets:
         return
 
@@ -272,63 +272,54 @@ def quickstart():
     width = click.get_terminal_size()[0]
     width = width if width <= 79 else 79
 
+
     click.secho("twtxt - quickstart", fg="cyan")
     click.secho("==================", fg="cyan")
     click.echo()
-    # change to old version
-     help_text = "This wizard will generate a basic configuration file for twtxt with all mandatory options set. " \
-                "Have a look at the README.rst to get information about the other available options and their meaning."
+# change to old version
+    help_text = "This wizard will generate a basic configuration file for twtxt with all mandatory options set. " \
+            "You can change all of these later with either twtxt itself or by editing the config file manually. " \
+            "Have a look at the docs to get information about the other available options and their meaning."
     click.echo(textwrap.fill(help_text, width))
 
     click.echo()
     nick = click.prompt("➤ Please enter your desired nick", default=os.environ.get("USER", ""))
 
 
-
-#comp490 from here (overwrite_check is from twtxt's latest update from buckket, however is  heavily modified because it didn't do what specifications required)
-    def overwrite_check(path): 
-
+    def overwrite_check(path):
         if os.path.isfile(path):
-            if click.confirm("➤ '{0}' already exists. Overwrite?".format(path)):
-               print("file will be overwritten")
-            else:
-                cfgfile = click.prompt("➤ Please enter the desired location for your config file",
-                os.path.join(Config.config_dir, Config.config_name),
-                type=click.Path(readable=True, writable=True, file_okay=True))
-
-    def determineCF(path): #comp490
+            click.confirm("➤ '{0}' already exists. Overwrite?".format(path), abort=True)
+			
+	def overwrite_check_con(path):
         if os.path.isfile(path):
-            if click.confirm("➤ '{0}' already exists. Overwrite?".format(path)):
-                print("file will be overwritten")
-                return path
-            else:
-                cfgfile = click.prompt("➤ Please enter the desired location for your config file",
-                                        os.path.join(Config.config_dir, Config.config_name),
-                                        type=click.Path(readable=True, writable=True, file_okay=True))
-                return cfgfile
+            click.confirm("➤ '{0}' already exists. Overwrite?".format(path), abort=False)	
 
-    #cfgfile = os.path.expanduser(cfgfile) 
-    cfgfile = os.path.join(Config.config_dir, Config.config_name) #comp490
-    cfgfile = determineCF(cfgfile) #comp490
-#comp490 to here
+    #cfgfile = click.prompt("➤ Please enter the desired location for your config file",
+                               #os.path.join(Config.config_dir, Config.config_name),
+                               #type=click.Path(readable=True, writable=True, file_okay=True))
+    #cfgfile = os.path.expanduser(cfgfile)
+    configf = os.path.join(Config.config_dir, Config.config_name)
+    overwrite_check_con(configf)
 
     twtfile = click.prompt("➤ Please enter the desired location for your twtxt file",
                            os.path.expanduser("~/twtxt.txt"),
                            type=click.Path(readable=True, writable=True, file_okay=True))
 
+
     twtfile = os.path.expanduser(twtfile)
     overwrite_check(twtfile)
 
+
     twturl = click.prompt("➤ Please enter the URL your twtxt file will be accessible from",
-                          default="https://example.org/twtxt.txt")
+                      default="https://example.org/twtxt.txt")
 
     disclose_identity = click.confirm("➤ Do you want to disclose your identity? Your nick and URL will be shared when "
-                                      "making HTTP requests", default=False)
+                                  "making HTTP requests", default=False)
 
     click.echo()
     add_news = click.confirm("➤ Do you want to follow the twtxt news feed?", default=True)
 
-    conf = Config.create_config(cfgfile, nick, twtfile, twturl, disclose_identity, add_news)
+    conf = Config.create_config(configf, nick, twtfile, twturl, disclose_identity, add_news)
     open(os.path.expanduser(twtfile), "a").close()
 
     twtfile_dir = os.path.dirname(twtfile)

--- a/twtxt/cache.py
+++ b/twtxt/cache.py
@@ -1,9 +1,7 @@
 """
     twtxt.cache
     ~~~~~~~~~~~
-
     This module implements a caching system for storing tweets.
-
     :copyright: (c) 2016 by buckket.
     :license: MIT, see LICENSE for more details.
 """
@@ -11,24 +9,27 @@
 import logging
 import os
 import shelve
+from time import time as timestamp
 
-import click
+from click import get_app_dir
 
 logger = logging.getLogger(__name__)
 
 
 class Cache:
-    cache_dir = click.get_app_dir("twtxt")
+    cache_dir = get_app_dir("twtxt")
     cache_name = "cache"
 
-    def __init__(self, cache_file, cache):
+    def __init__(self, cache_file, cache, update_interval):
         """Initializes new :class:`Cache` object.
-
-        :param cache_file: full path to the loaded cache file.
-        :param cache: a Shelve object, with cache loaded.
+        :param str cache_file: full path to the loaded cache file.
+        :param ~shelve.Shelve cache: a Shelve object, with cache loaded.
+        :param int update_interval: number of seconds the cache is considered to be
+                                    up-to-date without calling any external resources.
         """
         self.cache_file = cache_file
         self.cache = cache
+        self.update_interval = update_interval
 
     def __enter__(self):
         return self
@@ -37,20 +38,41 @@ class Cache:
         return self.close()
 
     @classmethod
-    def from_file(cls, file):
+    def from_file(cls, file, *args, **kwargs):
         """Try loading given cache file."""
         try:
             cache = shelve.open(file)
-            return cls(file, cache)
+            return cls(file, cache, *args, **kwargs)
         except OSError as e:
             logger.debug("Loading {0} failed".format(file))
             raise e
 
     @classmethod
-    def discover(cls):
+    def discover(cls, *args, **kwargs):
         """Make a guess about the cache file location an try loading it."""
         file = os.path.join(Cache.cache_dir, Cache.cache_name)
-        return cls.from_file(file)
+        return cls.from_file(file, *args, **kwargs)
+
+    @property
+    def last_updated(self):
+        """Returns *NIX timestamp of last update of the cache."""
+        try:
+            return self.cache["last_update"]
+        except KeyError:
+            return 0
+
+    @property
+    def is_valid(self):
+        """Checks if the cache is considered to be up-to-date."""
+        if timestamp() - self.last_updated <= self.update_interval:
+            return True
+        else:
+            return False
+
+    def mark_updated(self):
+        """Mark cache as updated at current *NIX timestamp"""
+        if not self.is_valid:
+            self.cache["last_update"] = timestamp()
 
     def is_cached(self, url):
         """Checks if specified URL is cached."""
@@ -70,6 +92,7 @@ class Cache:
         """Adds new tweets to the cache."""
         try:
             self.cache[url] = {"last_modified": last_modified, "tweets": tweets}
+            self.mark_updated()
             return True
         except TypeError:
             return False
@@ -78,6 +101,7 @@ class Cache:
         """Retrieves tweets from the cache."""
         try:
             tweets = self.cache[url]["tweets"]
+            self.mark_updated()
             return sorted(tweets, reverse=True)[:limit]
         except KeyError:
             return []
@@ -86,6 +110,7 @@ class Cache:
         """Tries to remove cached tweets."""
         try:
             del self.cache[url]
+            self.mark_updated()
             return True
         except KeyError:
             return False

--- a/twtxt/cache.py
+++ b/twtxt/cache.py
@@ -9,27 +9,23 @@
 import logging
 import os
 import shelve
-from time import time as timestamp
 
-from click import get_app_dir
+import click
 
 logger = logging.getLogger(__name__)
 
 
 class Cache:
-    cache_dir = get_app_dir("twtxt")
+    cache_dir = click.get_app_dir("twtxt")
     cache_name = "cache"
 
-    def __init__(self, cache_file, cache, update_interval):
+    def __init__(self, cache_file, cache):
         """Initializes new :class:`Cache` object.
-        :param str cache_file: full path to the loaded cache file.
-        :param ~shelve.Shelve cache: a Shelve object, with cache loaded.
-        :param int update_interval: number of seconds the cache is considered to be
-                                    up-to-date without calling any external resources.
+        :param cache_file: full path to the loaded cache file.
+        :param cache: a Shelve object, with cache loaded.
         """
         self.cache_file = cache_file
         self.cache = cache
-        self.update_interval = update_interval
 
     def __enter__(self):
         return self
@@ -38,41 +34,20 @@ class Cache:
         return self.close()
 
     @classmethod
-    def from_file(cls, file, *args, **kwargs):
+    def from_file(cls, file):
         """Try loading given cache file."""
         try:
             cache = shelve.open(file)
-            return cls(file, cache, *args, **kwargs)
+            return cls(file, cache)
         except OSError as e:
             logger.debug("Loading {0} failed".format(file))
             raise e
 
     @classmethod
-    def discover(cls, *args, **kwargs):
+    def discover(cls):
         """Make a guess about the cache file location an try loading it."""
         file = os.path.join(Cache.cache_dir, Cache.cache_name)
-        return cls.from_file(file, *args, **kwargs)
-
-    @property
-    def last_updated(self):
-        """Returns *NIX timestamp of last update of the cache."""
-        try:
-            return self.cache["last_update"]
-        except KeyError:
-            return 0
-
-    @property
-    def is_valid(self):
-        """Checks if the cache is considered to be up-to-date."""
-        if timestamp() - self.last_updated <= self.update_interval:
-            return True
-        else:
-            return False
-
-    def mark_updated(self):
-        """Mark cache as updated at current *NIX timestamp"""
-        if not self.is_valid:
-            self.cache["last_update"] = timestamp()
+        return cls.from_file(file)
 
     def is_cached(self, url):
         """Checks if specified URL is cached."""
@@ -92,7 +67,6 @@ class Cache:
         """Adds new tweets to the cache."""
         try:
             self.cache[url] = {"last_modified": last_modified, "tweets": tweets}
-            self.mark_updated()
             return True
         except TypeError:
             return False
@@ -101,7 +75,6 @@ class Cache:
         """Retrieves tweets from the cache."""
         try:
             tweets = self.cache[url]["tweets"]
-            self.mark_updated()
             return sorted(tweets, reverse=True)[:limit]
         except KeyError:
             return []
@@ -110,7 +83,6 @@ class Cache:
         """Tries to remove cached tweets."""
         try:
             del self.cache[url]
-            self.mark_updated()
             return True
         except KeyError:
             return False

--- a/twtxt/cli.py
+++ b/twtxt/cli.py
@@ -276,7 +276,7 @@ def quickstart():
     click.secho("==================", fg="cyan")
     click.echo()
     # change to old version
-     help_text = "This wizard will generate a basic configuration file for twtxt with all mandatory options set. " \
+    help_text = "This wizard will generate a basic configuration file for twtxt with all mandatory options set. " \
                 "Have a look at the README.rst to get information about the other available options and their meaning."
     click.echo(textwrap.fill(help_text, width))
 


### PR DESCRIPTION
 "using  twtxt quickstart make the twtxt.txt file in a directory that didn't exist, gives an error; it 
 should create the directories in a non-os dependent way (meaning it should work on Mac/Windows"
Not fixed.  Continuing to work on it but I wanted to send you so far
   
"currently twtxt quickstart will overwrite an existing config file: Quickstart must not overwrite existing config. It should detect the file there already and not overwrite it."
fixed
   
"When using twtxt quickstart, if the --config path doesn't exist, twtxt should use the default config instead of giving an error (as it does now)"
fixed